### PR TITLE
Fixed crashing issues

### DIFF
--- a/Game/3d-game-project/3D/Object/Interaction/playerInteractor.gd
+++ b/Game/3d-game-project/3D/Object/Interaction/playerInteractor.gd
@@ -95,4 +95,6 @@ func interact_with_nuclear_reactor_building(building: NuclearReactorBuilding):
 	if held_object:
 		building.holding = true
 		held_object = null
+	else:
+		building.holding = false
 	building._on_interactable_interacted(self)

--- a/Game/3d-game-project/gameController.gd
+++ b/Game/3d-game-project/gameController.gd
@@ -110,7 +110,7 @@ func enter_power_plant(holdingCard) -> void:
 		
 func exit_power_plant() -> void:
 	var removeCard = false
-	if power_plant_instance.get_child(0) and power_plant_instance.get_child(0).objectives.count(true) == 3:
+	if power_plant_instance.get_child(0) and power_plant_instance.get_child(0).givenCard:
 		removeCard = true
 	# Remove the current child (if any)
 	for child in get_children():
@@ -122,5 +122,5 @@ func exit_power_plant() -> void:
 	else:
 		zone2_instance = zone2.instantiate()
 		add_child(zone2_instance)
-	if zone2_instance.get_child(1) and removeCard:
+	if zone2_instance.get_node("Card") and removeCard:
 		zone2_instance.get_node("Card").queue_free()


### PR DESCRIPTION
This pull request includes several changes to improve the interaction with the nuclear reactor building and the power plant in the game. The most important changes include updating the logic for handling objects in the nuclear reactor building and modifying the conditions for card removal in the power plant.

Improvements to nuclear reactor building interaction:

* [`Game/3d-game-project/3D/Object/Interaction/playerInteractor.gd`](diffhunk://#diff-cde007eeb0f0b59a2cdc53a41d515dfbc17004d5019a93c1ef5782b62add1992R98-R99): Added logic to set `building.holding` to `false` when no object is held.

Enhancements to power plant logic:

* [`Game/3d-game-project/gameController.gd`](diffhunk://#diff-60d499d137168ca1b61604804aa8f906b140bc897a98ccf6e5a41622cf67e07bL113-R113): Changed the condition for removing a card in `exit_power_plant` from checking objectives to checking if a card was given.
* [`Game/3d-game-project/gameController.gd`](diffhunk://#diff-60d499d137168ca1b61604804aa8f906b140bc897a98ccf6e5a41622cf67e07bL125-R125): Updated the condition to check for a node named "Card" instead of a child at a specific index before removing the card.Some issues that crashed the game have been fixed.